### PR TITLE
Resolves logging in and/or resetting of password errors

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1052,7 +1052,7 @@ function _pacrypt_dovecot($pw, $pw_db = '') {
     // Read hash from pipe stdout
     $password = fread($pipes[1], 200);
 
-    if (!empty($stderr_output) || empty($password)) {
+    if (!empty($stderr_output) && empty($password)) {
         error_log("Failed to read password from $dovecotpw ... stderr: $stderr_output, password: $password ");
         throw new Exception("$dovecotpw failed, see error log for details");
     }


### PR DESCRIPTION
The changes allows the function to succeed only if the password has generated and available in the $pipe[1] regardless if an error occurs and is available in $pipe[2];